### PR TITLE
Rewrite module

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,3 +1,5 @@
 fixtures:
+  repositories:
+    stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib"
   symlinks:
    "nscd": "#{source_dir}"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Does little more than install the nscd package
 and support the on/off of databases passwd,
 groups and hosts to cache or not.
 
-See class::config for details.
+See class::nscd for details.
 
 Tested on RHEL and Fedora.
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,60 +1,10 @@
-#
 # == Class nscd::config
-# Configures nscd:
+# Configures nscd.
 #
-# === Parameters
-# [*nscd_hosts_cache*]
-# Set to yes or no, should hosts be cached or not by nscd.
-# Default: yes
-#
-# [*nscd_group_cache*]
-# Set to yes or no, should hosts be cached or not by nscd.
-# Default: no
-# 
-# [*nscd_passwd_cache*]
-# Set to yes or no, should hosts be cached or not by nscd.
-# Default: no
-#
-# [*nscd_paranoia*]
-# Set to yes or no, should paranoia be used, default no.
-#
-# [*nscd_restart_interval*]
-# Inteval in seconds to restart at if paranoid. Default 360 seconds.
-
-# === Authors
-# Steve Traylen, CERN, <steve.traylen@cern.ch>
-#
-class nscd::config ($nscd_hosts_cache  = hiera('nscd_hosts_cache','yes'),
-  $nscd_passwd_cache = hiera('nscd_passwd_cache','no'),
-  $nscd_group_cache  = hiera('nscd_group_cache','no'),
-  $nscd_service_cache  = hiera('nscd_service_cache','yes'),
-  $nscd_threads = hiera('nscd_threads','4'),
-  $nscd_paranoia  = hiera('nscd_paranoia','no'),
-  $nscd_restart_interval  = hiera('nscd_restart_interval','3600')
-) {
-
-  if ! ( $nscd_hosts_cache in ['yes','no'] ) {
-    fail('nscd_hosts_cache must be yes or no')
-  }
-  if ! ( $nscd_passwd_cache in ['yes','no'] ) {
-    fail('nscd_hosts_cache must be yes or no')
-  }
-  if ! ( $nscd_group_cache in ['yes','no'] ) {
-    fail('nscd_hosts_cache must be yes or no')
-  }
-  if ! ( $nscd_service_cache in ['yes','no'] ) {
-    fail('nscd_service_cache must be yes or no')
-  }
-  if ! ( $nscd_paranoia in ['yes','no'] ) {
-    fail('nscd_paranoia must be yes or no')
-  }
-
-
+class nscd::config {
   file{'/etc/nscd.conf':
     ensure  => present,
     content => template('nscd/nscd.conf.erb'),
-    require => Package['nscd'],
-    notify  => Service['nscd']
   }
 }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,7 +1,7 @@
 # == Class nscd::config
 # Configures nscd.
 #
-class nscd::config {
+class nscd::config inherits nscd {
   file{'/etc/nscd.conf':
     ensure  => present,
     content => template('nscd/nscd.conf.erb'),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,7 +60,7 @@
 #
 # Steve Traylen <steve.traylen@cern.ch>
 # Arnold Bechtoldt <mail@arnoldbechtoldt.com>
-# Martin Pfeifer <martin.pfeifer@dm.de>
+# Martin Pfeifer <martin.pfeifer@gmail.com>
 #
 # === Copyright
 #

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,30 +3,111 @@
 # Manages /etc/nscd.conf file and service.
 #
 # === Parameters
-# The nscd::config class takes variables from hiera.
-
-# === Variables
+#  pkg_ensure                   Desired state of nscd package.
+#                               Default is present.
+#                               type: string
+#                               valid values: 'present' or 'absent' or 'lastest'
+#
+#  service_ensure               Desired state of nscd service.
+#                               Default is running.
+#                               type: string
+#                               valid values: 'running' or 'stopped'
+#
+#  service_enable               Should nscd start on boot.
+#                               Default is true.
+#                               type: boolean
+#
+#                               valid values: true or false
+#  nscd_hosts_cache::           Should nscd cache hosts queries.
+#                               Default is yes.
+#                               type: string
+#                               valid values: 'yes' or 'no'
+#
+#  nscd_passwd_cache::          Should nscd cache passwd queries.
+#                               Default is no.
+#                               type: string
+#                               valid values: 'yes' or 'no'
+#
+#  nscd_group_cache::           Should nscd cache group queries.
+#                               Default is no.
+#                               type: string
+#                               valid values: 'yes' or 'no'
+#
+#  nscd_service_cache::         Should nscd cache service queries.
+#                               Default is yes.
+#                               type: string
+#                               valid values: 'yes' or 'no'
+#
+#  nscd_threads::               How many threads should nscd use.
+#                               Default is 4.
+#                               type: integer
+#
+#  nscd_paranoia::              Should nscd restart itself periodically.
+#                               Default is no.
+#                               type: string
+#                               valid values: 'yes' or 'no'
+#
+#  nscd_restart_interval::      The interval in that nscd restarts itself
+#                               if nscd_paranoia is enabled.
+#                               Default is 3600.
+#                               type: integer
 #
 # === Examples
 #
-#  class { nscd: }
+#  class { 'nscd': }
 #
 # === Authors
 #
 # Steve Traylen <steve.traylen@cern.ch>
 # Arnold Bechtoldt <mail@arnoldbechtoldt.com>
+# Martin Pfeifer <martin.pfeifer@dm.de>
 #
 # === Copyright
 #
 # Copyright 2011 CERN Steve Traylen
 #
 class nscd (
-  $pkg_ensure     = 'present',
-  $service_ensure = 'running',
-  $service_enable = true,
-  ) {
+  $pkg_ensure            = 'present',
+  $service_ensure        = 'running',
+  $service_enable        = true,
+  $nscd_hosts_cache      = hiera('nscd_hosts_cache','yes'),
+  $nscd_passwd_cache     = hiera('nscd_passwd_cache','no'),
+  $nscd_group_cache      = hiera('nscd_group_cache','no'),
+  $nscd_service_cache    = hiera('nscd_service_cache','yes'),
+  $nscd_threads          = hiera('nscd_threads','4'),
+  $nscd_paranoia         = hiera('nscd_paranoia','no'),
+  $nscd_restart_interval = hiera('nscd_restart_interval','3600')
+) {
 
-  class{'nscd::install':}
-  class{'nscd::config':}
-  class{'nscd::service':}
+  if ! ( $pkg_ensure in ['present','absent','latest'] ) {
+    fail('pkg_ensure must be present, absent or latest')
+  }
+  if ! ( $service_ensure in ['running','stopped'] ) {
+    fail('service_ensure must be running or stopped')
+  }
+  if ! ( $nscd_hosts_cache in ['yes','no'] ) {
+    fail('nscd_hosts_cache must be yes or no')
+  }
+  if ! ( $nscd_passwd_cache in ['yes','no'] ) {
+    fail('nscd_hosts_cache must be yes or no')
+  }
+  if ! ( $nscd_group_cache in ['yes','no'] ) {
+    fail('nscd_hosts_cache must be yes or no')
+  }
+  if ! ( $nscd_service_cache in ['yes','no'] ) {
+    fail('nscd_service_cache must be yes or no')
+  }
+  if ! ( $nscd_paranoia in ['yes','no'] ) {
+    fail('nscd_paranoia must be yes or no')
+  }
+
+  include ::nscd::install
+  include ::nscd::config
+  include ::nscd::service
+
+  anchor{"${name}::begin":}
+  -> Class['nscd::install']
+  -> Class['nscd::config']
+  ~> Class['nscd::service']
+  -> anchor{"${name}::end":}
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,8 +1,8 @@
 # == Class: nscd::install
 # Installs nscd packages.
 #
-class nscd::install {
+class nscd::install inherits nscd {
   package{'nscd':
-    ensure => $::nscd::pkg_ensure,
+    ensure => $pkg_ensure,
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,11 +1,8 @@
 # == Class: nscd::install
 # Installs nscd packages.
 #
-class nscd::install (
-  $pkg_ensure = $nscd::pkg_ensure,
-) inherits nscd {
-
+class nscd::install {
   package{'nscd':
-    ensure => $pkg_ensure,
+    ensure => $::nscd::pkg_ensure,
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,9 +1,9 @@
 # == Class: nscd::service
 # Controls the nscd service.
-class nscd::service {
+class nscd::service inherits nscd {
   service{'nscd':
-    ensure     => $::nscd::service_ensure,
-    enable     => $::nscd::service_enable,
+    ensure     => $service_ensure,
+    enable     => $service_enable,
     hasstatus  => true,
     hasrestart => true,
   }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,16 +1,10 @@
 # == Class: nscd::service
 # Controls the nscd service.
-class nscd::service (
-  $service_ensure = $nscd::service_ensure,
-  $service_enable = $nscd::service_enable
-) inherits nscd {
-
+class nscd::service {
   service{'nscd':
-    ensure     => $nscd::service_ensure,
-    enable     => $nscd::service_enable,
+    ensure     => $::nscd::service_ensure,
+    enable     => $::nscd::service_enable,
     hasstatus  => true,
     hasrestart => true,
-    require    => Class['nscd::config'],
-    subscribe  => Class['nscd::config']
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,9 @@
   "description": "Manages the /etc/nscd.conf file and service",
   "source": "https://github.com/cernops/puppet-nscd",
   "issues": "https://github.com/cernops/puppet-nscd/issues",
-  "dependencies": [ ],
+  "dependencies": [ 
+    { "name": "puppetlabs/stdlib", "version_requirement": ">=2.2.1" },
+  ],
   "operatingsystem_support": [
     { "operatingsystem": "RedHat",
       "operatingsystemrelease": [ "5.0", "6.0", "7.0" ]


### PR DESCRIPTION
I refactored the module to be a bit more modern style puppet code. The class interace is backward compatible the use of the anchor pattern might break the usage with very old puppet version (< 2.6.x).