### PR TITLE
ensure_packages to avoid duplicate redef

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,7 +4,5 @@
 class nscd::install (
   $pkg_ensure = $nscd::pkg_ensure
 ) inherits nscd {
-  package{'nscd':
-    ensure => $pkg_ensure,
-  }
+  ensure_packages('nscd', { ensure => $pkg_ensure, })
 }


### PR DESCRIPTION
stdlib ensure_packages is handy when I've not set hiera